### PR TITLE
Suggestion to python installation

### DIFF
--- a/DISF_demo.py
+++ b/DISF_demo.py
@@ -1,6 +1,3 @@
-import sys
-sys.path.append("./python3/");
-
 from disf import DISF_Superpixels
 from PIL import Image
 import matplotlib.pyplot as plt

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,7 @@ matlab: lib
 	matlab -nodisplay -nojvm -nosplash -r "mex $(MEX_DIR)/DISF_mex.c -I$(INCLUDE_DIR) -L$(LIB_DIR) -O -ldisf -lgomp -outdir $(MEX_DIR) -output DISF_Superpixels.mex; exit;" ;
 
 python3: lib
-	python3 python3/setup.py build_ext -b $(PYTHON3_DIR);
-	python3 python3/setup.py clean;
+	python3 python3/setup.py install;
 
 clean:
 	rm -rf $(OBJ_DIR)/* ;


### PR DESCRIPTION
This change installs the package on python's default directory, making it available to other directories without the `sys.path.append` hack.